### PR TITLE
Bump @enonic-types/* to ^8.0.0-B4

### DIFF
--- a/types/graphQL/CreateDataFetcherResult.d.ts
+++ b/types/graphQL/CreateDataFetcherResult.d.ts
@@ -1,7 +1,7 @@
-// Make sure ScriptValue type exists in global scope:
 /// <reference types="@enonic-types/global"/>
 
 
+import type {ScriptValue} from '@enonic-types/core'
 import type {
 	LocalContext,
 	LocalContextRecord,
@@ -12,7 +12,7 @@ export declare interface CreateDataFetcherResultParams<
 	In extends LocalContextRecord = LocalContext,
 	Out extends LocalContextRecord = LocalContext
 > {
-	data: ScriptValue // NOTE: ScriptValue type is expected to exist in global scope
+	data: ScriptValue
 	localContext?: LocalContext<Out>
 	parentLocalContext?: LocalContext<In>
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,6 @@
-// Make sure ScriptValue type exists in global scope:
 /// <reference types="@enonic-types/global"/>
+
+import type {ScriptValue} from '@enonic-types/core'
 
 
 declare const __name: unique symbol
@@ -39,7 +40,7 @@ export declare interface GraphQL {
 	In extends LocalContextRecord = LocalContext,
 	Out extends LocalContextRecord = LocalContext
 > () => {
-		data: ScriptValue // NOTE: ScriptValue type is expected to exist in global scope
+		data: ScriptValue
 		localContext?: LocalContext<Out>
 		parentLocalContext?: LocalContext<In>
 	}

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "^7.14.0",
-        "@enonic-types/global": "^7.14.0",
-        "@enonic-types/lib-content": "^7.14.0"
+        "@enonic-types/core": "^8.0.0-B4",
+        "@enonic-types/global": "^8.0.0-B4",
+        "@enonic-types/lib-content": "^8.0.0-B4"
       },
       "devDependencies": {
         "tsd": "^0.30.4",
@@ -179,21 +179,24 @@
       }
     },
     "node_modules/@enonic-types/core": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-7.14.0.tgz",
-      "integrity": "sha512-3AQSeJ7Taf7/xlzAeapwk8h+i3q7zHFWiESq/uU0sfVUo2pJYVo16mGfh8buHA657QvpDZKq+j4AhVWBrwl56w=="
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w=="
     },
     "node_modules/@enonic-types/global": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-7.14.0.tgz",
-      "integrity": "sha512-4GbxXuUbXQdLGNeE4e20evQJt50LK8H/VVQCqQ5StTuoUCB/JF55ZvQaJdBtc5A6F5obwf/dGyI24m4ZZZvzKg=="
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-8.0.0-B4.tgz",
+      "integrity": "sha512-CC7OQvPOtxMBfOhnLcDYaMxfdSIaYkbDQ8WnDmXPEPDHMNkraZhirLpdvAnS/7PObS/yEuS94x9GEAqmEd+YFQ==",
+      "dependencies": {
+        "@enonic-types/core": "8.0.0-B4"
+      }
     },
     "node_modules/@enonic-types/lib-content": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-content/-/lib-content-7.14.0.tgz",
-      "integrity": "sha512-jBIohUTq+gL6LcGXk3jN9XFoIN4lKWzcEdMVN1IzxZvwBjLlL7ROwfq0euS3a1dFXGQr9eYJX2ulXwLFqx1wEw==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-content/-/lib-content-8.0.0-B4.tgz",
+      "integrity": "sha512-KguGnlIpQRTTIXxeRQtKw0hQLn8cs03Jilfji8k0jFIWnxZ6zkSn3dK/9Ckivle8lq+sXKPRh2F+LlxLOd5sDA==",
       "dependencies": {
-        "@enonic-types/core": "7.14.0"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
     "node_modules/@jest/schemas": {

--- a/types/package.json
+++ b/types/package.json
@@ -4,9 +4,9 @@
     "url": "https://github.com/enonic/app-guillotine/issues"
   },
   "dependencies": {
-    "@enonic-types/core": "^7.14.0",
-    "@enonic-types/global": "^7.14.0",
-    "@enonic-types/lib-content": "^7.14.0"
+    "@enonic-types/core": "^8.0.0-B4",
+    "@enonic-types/global": "^8.0.0-B4",
+    "@enonic-types/lib-content": "^8.0.0-B4"
   },
   "description": "Types for Guillotine extensions",
   "devDependencies": {


### PR DESCRIPTION
## Summary

Bump the `@enonic-types/*` deps consumed by the `@enonic-types/guillotine` type package from `^7.14.0` to `^8.0.0-B4`, aligning with the XP 8 type definitions (see [doc-code 967803a](https://github.com/enonic/doc-code/commit/967803a7f343e4a72eb91ae7c2ae98f7aaa33bef)).

- `types/package.json`: `@enonic-types/core`, `@enonic-types/global`, `@enonic-types/lib-content` → `^8.0.0-B4`
- `types/package-lock.json` refreshed
- In `@enonic-types/global` 8.x, `ScriptValue` is no longer declared in the global scope — it is exported from `@enonic-types/core`. Add explicit `import type {ScriptValue} from '@enonic-types/core'` in `types/index.ts` and `types/graphQL/CreateDataFetcherResult.d.ts` so `tsc --noEmit` and `tsd` still pass.
- The `@enonic-types/guillotine` package's own version is **not** bumped — that is a separate release decision.

## Test plan

- [x] `cd types && npm install`
- [x] `npm run check` (tsc --noEmit) — green
- [x] `npm test` (tsd) — green
- [x] `npm run build` (root webpack) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)