### PR TITLE
Bump enonic libs to next major SNAPSHOTs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     include "com.enonic.xp:lib-app:${xpVersion}"
     include "com.enonic.xp:lib-context:${xpVersion}"
     include "com.enonic.lib:lib-mustache:2.1.1"
-    include "com.enonic.lib:lib-static:2.1.1"
-    include "com.enonic.lib:lib-router:3.2.0"
+    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
 
     testImplementation(platform("org.junit:junit-bom:6.0.3"))
     testImplementation(platform("org.mockito:mockito-bom:5.23.0"))


### PR DESCRIPTION
- lib-router 3.2.0 → 4.0.0-SNAPSHOT
- lib-static 2.1.1 → 3.0.0-SNAPSHOT

Direct push to master is blocked by branch protection.