### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,25 +37,25 @@ dependencies {
     implementation "com.enonic.xp:core-api:${xpVersion}"
     implementation "com.enonic.xp:script-api:${xpVersion}"
     implementation "com.enonic.xp:portal-api:${xpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.21.3"
+    implementation libs.jackson.databind
 
-    include "com.graphql-java:graphql-java:26.0"
-    include "com.graphql-java:graphql-java-extended-scalars:24.0"
+    include libs.graphql.java
+    include libs.graphql.java.extended.scalars
 
     include "com.enonic.xp:lib-admin:${xpVersion}"
     include "com.enonic.xp:lib-portal:${xpVersion}"
     include "com.enonic.xp:lib-event:${xpVersion}"
     include "com.enonic.xp:lib-app:${xpVersion}"
     include "com.enonic.xp:lib-context:${xpVersion}"
-    include "com.enonic.lib:lib-mustache:2.1.1"
-    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
+    include libs.lib.mustache
+    include libs.lib.static
+    include libs.lib.router
 
-    testImplementation(platform("org.junit:junit-bom:6.0.3"))
-    testImplementation(platform("org.mockito:mockito-bom:5.23.0"))
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(platform(libs.mockito.bom))
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.platform.launcher
+    testImplementation libs.mockito.junit.jupiter
     testImplementation "com.enonic.xp:testing:${xpVersion}"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,22 @@
+[versions]
+graphql-java = "26.0"
+graphql-java-extended-scalars = "24.0"
+jackson = "2.21.3"
+junit = "6.0.3"
+mockito = "5.23.0"
+mustache = "2.1.1"
+router = "4.0.0-SNAPSHOT"
+static = "3.0.0-SNAPSHOT"
+
+[libraries]
+graphql-java = { module = "com.graphql-java:graphql-java", version.ref = "graphql-java" }
+graphql-java-extended-scalars = { module = "com.graphql-java:graphql-java-extended-scalars", version.ref = "graphql-java-extended-scalars" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
+lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }


### PR DESCRIPTION
## Summary

Migrate the inline dependency versions in `build.gradle` to a new `gradle/libs.versions.toml` catalog. This aligns `app-guillotine` with the ~half of repos in the IdeaProjects tree that already use a catalog, making future bulk dependency sweeps (XP 8 SNAPSHOTs, etc.) a single-sed affair across the whole org.

This is a pin-for-pin migration — no version bumps, no behavior changes. The resolved `include`, `runtimeClasspath`, and `testRuntimeClasspath` trees were diffed before/after and are identical.

## Conventions adopted

- Version keys are short, lowercase, hyphen-separated (`http-client`, not `httpClient`).
- Library keys for `com.enonic.lib:lib-*` artifacts keep the `lib-` prefix; the version key drops it (matches the task example and `app-chucknorris` style).
- `[versions]` and `[libraries]` sorted alphabetically.
- `version.ref` everywhere — no inline `version = "x.y"`.
- `xpVersion` left in `gradle.properties` (the rest of the toolchain expects it there).
- `xplibs.*` accessor pattern not in scope — not touched.

## Catalog

```toml
[versions]
graphql-java = "26.0"
graphql-java-extended-scalars = "24.0"
jackson = "2.21.3"
junit = "6.0.3"
mockito = "5.23.0"
mustache = "2.1.1"
router = "4.0.0-SNAPSHOT"
static = "3.0.0-SNAPSHOT"

[libraries]
graphql-java = { module = "com.graphql-java:graphql-java", version.ref = "graphql-java" }
graphql-java-extended-scalars = { module = "com.graphql-java:graphql-java-extended-scalars", version.ref = "graphql-java-extended-scalars" }
jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
```

## Verification

- \`./gradlew build --refresh-dependencies\` green locally.
- \`./gradlew dependencies --configuration {include,runtimeClasspath,testRuntimeClasspath}\` byte-identical to pre-migration HEAD.

## Test plan

- [ ] CI green
- [ ] Resolved dependency tree on CI matches pre-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)