### PR TITLE
fix: prevent webpack module ID collision with Content Studio in production #1373

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ module.exports = {
         'styles/query-playground': './styles/query-playground.less',
     },
     output: {
-        path: path.join(__dirname, '/build/resources/main/assets')
+        path: path.join(__dirname, '/build/resources/main/assets'),
+        uniqueName: 'app-guillotine',
     },
     resolve: {
         extensions: ['.ts', '.js', '.tsx', '.less', '.css']


### PR DESCRIPTION
## Changes

- Set `output.uniqueName: 'app-guillotine'` in `webpack.config.js` so the bundle uses its own chunk-loading global (`webpackChunkapp_guillotine`) instead of the shared default `webpackChunk`.

In production, Guillotine's bundle and Content Studio's bundle both registered chunks under the same default `self.webpackChunk` global. When Content Studio lazy-loaded a chunk, both runtimes' callbacks fired and Content Studio's modules were merged into Guillotine's registry; with numeric (deterministic) module IDs the IDs collided and corrupted the registry, throwing `__webpack_modules__[moduleId] is undefined`. Dev builds were unaffected because module IDs are path-based strings there. A unique output name gives Guillotine an isolated registry.

> [!IMPORTANT]
> This also needs to land on the `8.x` branch — please cherry-pick after merge. The `8.x` output block already has `chunkFilename`, so the cherry-pick may need a trivial context fixup.

Closes #1373

<sub>*Drafted with AI assistance*</sub>
