### PR TITLE
Move npm publishing into build-and-publish #1435

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -17,16 +17,10 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             8.x
-
-      - name: Upload npm package
-        if: steps.build-and-publish.outputs.release == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: npm-package
-          path: build/types
 
   release:
     runs-on: ubuntu-latest
@@ -37,31 +31,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Download npm package
-        uses: actions/download-artifact@v8
-        with:
-          name: npm-package
-          path: build/types
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24.x'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Set npm tag
-        run: |
-          VERSION=$(grep '^version' gradle.properties | cut -d'=' -f2 | tr -d ' ')
-          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "NPM_TAG=latest" >> $GITHUB_ENV
-          else
-            echo "NPM_TAG=beta" >> $GITHUB_ENV
-          fi
-
-      - name: Publish to npm
-        working-directory: build/types
-        run: npx -y npm@latest publish --tag $NPM_TAG --ignore-scripts
 
       - uses: enonic/release-tools/release@master
         with:


### PR DESCRIPTION
Folds `@enonic-types/guillotine` publishing into the shared `build-and-publish` action via `npmPublish` (enonic/release-tools#71 — publish-only, `--ignore-scripts`), gated on `build-and-publish.outputs.release`.

- `build` job: pass `npmPublish: true`.
- Removed the `Upload npm package` step and the release job's Download / Set up Node / Set npm tag / Publish steps. `build/types` is produced by Gradle's `assembleTypes` (`publish.dependsOn assembleTypes`), so no rebuild or artifact shuffle is needed; the action publishes it with `--ignore-scripts` (matching the old behavior).
- Kept the GitHub `release@master` job.

**Merge order:** land enonic/release-tools#71 first.

Closes #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)